### PR TITLE
Import and prettify images when run from pop-up menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pretty Image Loader
 
-Image loading tool for the Blender video editor (sequencer). This Blender addon loads prettier images with transparency and original image dimensions instead of default settings and wonkily stretched/squashed dimensions.
+Strip loading tool for the Blender video editor (sequencer). This Blender addon loads prettier images and movies with transparency and original image dimensions instead of default settings and wonkily stretched/squashed dimensions.
 
 ## Getting Started
 

--- a/__init__.py
+++ b/__init__.py
@@ -23,7 +23,7 @@ def register():
     register_class(ui.PrettyImageHandler)
 
 def unregister():
-    register_class(ui.PrettyImageHandler)
+    unregister_class(ui.PrettyImageHandler)
     unregister_class(ui.PrettyImageOperator)
     bpy.types.SEQUENCER_MT_add.remove(ui.menu_add)
 

--- a/__init__.py
+++ b/__init__.py
@@ -17,24 +17,14 @@ bl_info = {
     "category": "VSE"
 }
 
-# def register_modules(modules, unregister=False):
-#     for module in modules:
-#         for member in inspect.getmembers(module, inspect.isclass):
-#             memberClass = member[1]
-#             try:
-#                 registration = unregister_class(memberClass) if unregister else register_class(memberClass)
-#             except RuntimeError:
-#                 print("Failed to load module member class {0}. Skipping for now.".format(memberClass))
-#     return
-
 def register():
     bpy.types.SEQUENCER_MT_add.append(ui.menu_add)
-    # register_modules([ui])
     register_class(ui.PrettyImageOperator)
+    register_class(ui.PrettyImageHandler)
 
 def unregister():
-    register_class(ui.PrettyImageOperator)
-    # register_modules(reversed([ui]), unregister=True)
+    register_class(ui.PrettyImageHandler)
+    unregister_class(ui.PrettyImageOperator)
     bpy.types.SEQUENCER_MT_add.remove(ui.menu_add)
 
 if __name__ == '__main__':

--- a/test_cases.md
+++ b/test_cases.md
@@ -1,0 +1,34 @@
+# Pretty Strip Test Cases
+
+A list of steps to check that Pretty Strip works as expected. TODO: automate unit py testing.
+
+## Navigating the UI
+
+Does the interface populate and behave as expected?
+- [ ] header menu contains `Add` submenu displaying the add-on name
+- [ ] Add pop-up menu displays the add-on name
+- [ ] header runs the main operation
+- [ ] pop-up runs the main operation
+
+## Executing the main operation
+
+TODO: support movies but ignore non-img/clip file types
+Expected: the file browser opens, and any imported images and movies are made into strips with transparency and dimensions matching source images/movies.
+
+Can `pretty_script_add` load and prettify as expected?
+- [ ] file browser opens from header
+- [ ] file browser opens from pop-up
+- [ ] one image from header
+- [ ] one image from pop-up
+- [ ] one movie from header
+- [ ] one movie from pop-up
+- [ ] multiple images from each
+- [ ] multiple movies from each
+- [ ] no data (file browser cancel)
+- [ ] non-images/movies (incompatible files like sounds, txt get ignored)
+- [ ] one image from pop-up then another from header
+- [ ] one image from pop-up then another from pop-up
+
+## VSE output
+- [ ] strip imported at same frame as another stacks
+- [ ] transform strip appears above the base pretty img/clip

--- a/ui.py
+++ b/ui.py
@@ -23,12 +23,12 @@ class PrettyImagePanel (bpy.types.Panel):
         #if sequencer.active_strip: return
 
         row = self.layout.row()
-        row.operator("strip.add_pretty", text="Add Pretty Image")
+        row.operator("sequencer.pretty_strip_add", text="Add Pretty Image")
 
 class PrettyImageOperator (bpy.types.Operator):
     # Blender UI label, id and description
     bl_label = "Pretty Image Operator"
-    bl_idname = 'strip.add_pretty'
+    bl_idname = 'sequencer.pretty_strip_add'
     bl_description = "Add a new image with alpha, transform strip and proper dimensions."
     # import settings
     filepath = StringProperty (name='File Path')
@@ -48,7 +48,7 @@ class PrettyImageOperator (bpy.types.Operator):
         return img_filenames
 
     def execute (self, ctx):
-        print("\n\nRestarting PRETTY IMG LOADER...")
+        print("\nRunning operator for PRETTY IMG LOADER")
         bpy.context.scene.sequence_editor_create()  # verify vse is valid in scene
         img_filenames = self.store_files(self.files)
         img_path = self.directory
@@ -56,12 +56,20 @@ class PrettyImageOperator (bpy.types.Operator):
             load_scale_img(filename, "{0}{1}".format(img_path, filename), scale=self.img_scale, length=self.length, alpha=self.set_alpha)
         return {'FINISHED'}
 
-    # TODO file manager does not show after first img loaded - op keeps placing prev img
+    # TODO file manager does not show in pop-up menu - op keeps placing prev img
 
     def invoke (self, context, event):
+        print("\nRunning invoke - see file browser")
         context.window_manager.fileselect_add(self)
         return {'RUNNING_MODAL'}
 
+class PrettyImageHandler (bpy.types.Operator):
+    bl_label = "Pretty Image Handler"
+    bl_idname = 'sequencer.pretty_strip_handler'
+    def execute (self, ctx):
+        bpy.ops.sequencer.pretty_strip_add('INVOKE_DEFAULT')
+        return {'FINISHED'}
+
 def menu_add(self, ctx):
     layout = self.layout
-    layout.operator(PrettyImageOperator.bl_idname, text="Pretty Image")
+    layout.operator('sequencer.pretty_strip_handler', text="Pretty Strip")


### PR DESCRIPTION
The update is built around a handler for `pretty_strip_add` that always calls the operator's `invoke` even when run from the <kbd>Shift + A</kbd> pop-up menu - closes #2.

Tested manually in all possible cases listed in the newly added test file.